### PR TITLE
fix data_types::get_data error example and add test

### DIFF
--- a/hutils/data_types.py
+++ b/hutils/data_types.py
@@ -27,7 +27,7 @@ def get_data(data, optional=False, *keys):
     """ 从字典数据类型中批量获取变量。get list data from dict.
 
     Example:
-        offset, limit, from_date, to_date = get_data(request.data, 'offset', 'limit', 'from', 'to')
+        offset, limit, from_date, to_date = get_data(request.data, optional=False, 'offset', 'limit', 'from', 'to')
 
     :type data: dict
     :type keys: str

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from hutils import data_types
+
+
+class TestDataTypes(unittest.TestCase):
+    def test_get_data(self):
+        test_cases = [
+            ({}, False, [], []),
+            ({
+                'a': 1
+            }, False, ['a'], [1]),
+            ({
+                'a': 1,
+                'b': 2
+            }, True, ['a', 'c'], [1, None]),
+        ]
+        for data, optional, keys, expect in test_cases:
+            res = data_types.get_data(data, optional, *keys)
+            self.assertListEqual(list(res), expect)


### PR DESCRIPTION
`get_data` 在 `Python3` 返回的是 `generator`, `Python2` 是 `list` 不会很奇怪吗？
为什么要支持 `Python2`, 只是  `Python3` 的话可以使用 

```
def get_data(data, *keys, optional=False):
    pass
``` 
就不会出现 `Example` 的错误了